### PR TITLE
Add support for version command class + update SensorBinary and Alarm

### DIFF
--- a/Test.ZWave/Program.cs
+++ b/Test.ZWave/Program.cs
@@ -122,10 +122,24 @@ namespace Test.ZWave
                 Console.WriteLine("    Specific Class {0}", node.SpecificClass);
                 Console.WriteLine("    Secure Info {0}", BitConverter.ToString(node.SecuredNodeInformationFrame));
                 Console.WriteLine("    Node Info {0}", BitConverter.ToString(node.NodeInformationFrame));
-                foreach (var cclass in node.SupportedCommandClasses)
+                foreach (CommandClass cclass in node.SupportedCommandClasses)
                 {
-                    Console.WriteLine("        {0}", cclass);
+                    byte version = node.GetCmdClassVersion(cclass);
+                    string versionStr = version == 0 ? "?" : version.ToString();
+
+                    if (!Enum.IsDefined(typeof(CommandClass), cclass))
+                    {
+                        byte cc = (byte)cclass;
+                        Console.ForegroundColor = ConsoleColor.Red;
+                        Console.WriteLine("        Unsupported class 0x{0} (version {1})", cc.ToString("X2"), versionStr);
+                    }
+                    else
+                    {
+                        Console.ForegroundColor = ConsoleColor.White;
+                        Console.WriteLine("        {0} (version {1})", cclass, versionStr);
+                    }
                 }
+                Console.ForegroundColor = ConsoleColor.White;
                 if (node.GetData("RoutingInfo") != null)
                 {
                     Console.WriteLine("    Routing Info {0}", BitConverter.ToString((byte[])node.GetData("RoutingInfo")));

--- a/ZWaveLib/CommandClasses/SensorBinary.cs
+++ b/ZWaveLib/CommandClasses/SensorBinary.cs
@@ -105,6 +105,7 @@ namespace ZWaveLib.CommandClasses
                     case ZWaveSensorBinaryParameter.Freeze:
                     case ZWaveSensorBinaryParameter.Auxiliary:
                     case ZWaveSensorBinaryParameter.Tilt:
+                    case ZWaveSensorBinaryParameter.General:
                     default:
                         // Catch-all for the undefined types above.
                         eventType = EventParameter.SensorGeneric;

--- a/ZWaveLib/CommandClasses/Version.cs
+++ b/ZWaveLib/CommandClasses/Version.cs
@@ -1,18 +1,18 @@
 ﻿/*
-    This file is part of HomeGenie Project source code.
+    This file is part of ZWaveLib Project source code.
 
-    HomeGenie is free software: you can redistribute it and/or modify
+    ZWaveLib is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    HomeGenie is distributed in the hope that it will be useful,
+    ZWaveLib is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with HomeGenie.  If not, see <http://www.gnu.org/licenses/>.  
+    along with ZWaveLib.  If not, see <http://www.gnu.org/licenses/>.  
 */
 
 /*

--- a/ZWaveLib/CommandClasses/Version.cs
+++ b/ZWaveLib/CommandClasses/Version.cs
@@ -1,0 +1,62 @@
+﻿/*
+    This file is part of HomeGenie Project source code.
+
+    HomeGenie is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    HomeGenie is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with HomeGenie.  If not, see <http://www.gnu.org/licenses/>.  
+*/
+
+/*
+*     Author: https://github.com/mdave
+*     Project Homepage: https://github.com/genielabs/zwave-lib-dotnet
+*/
+using System;
+using ZWaveLib.Values;
+
+namespace ZWaveLib.CommandClasses
+{
+    public class Version : ICommandClass
+    {
+        public CommandClass GetClassId()
+        {
+            return CommandClass.Version;
+        }
+
+        public NodeEvent GetEvent(ZWaveNode node, byte[] message)
+        {
+            NodeEvent nodeEvent = null;
+            Command type = (Command)message[1];
+
+            if (type == Command.VersionCommandClassReport)
+            {
+                if (!Enum.IsDefined(typeof(CommandClass), message[2]))
+                {
+                    return nodeEvent;
+                }
+                CommandClass cmdClass = (CommandClass)message[2];
+                VersionCmdClassValue value = new VersionCmdClassValue(cmdClass, message[3]);
+                nodeEvent = new NodeEvent(node, EventParameter.VersionCommandClass, value, 0);
+            }
+
+            return nodeEvent;
+        }
+
+        public static void Get(ZWaveNode node, CommandClass cmdClass)
+        {
+            node.SendDataRequest(new byte[] { 
+                (byte)CommandClass.Version, 
+                (byte)Command.VersionCommandClassGet,
+                (byte)cmdClass
+            });
+        }
+    }
+}

--- a/ZWaveLib/Enums/Command.cs
+++ b/ZWaveLib/Enums/Command.cs
@@ -112,6 +112,9 @@ namespace ZWaveLib
         WakeUpIntervalCapabilitiesGet = 0x09,
         WakeUpIntervalCapabilitiesReport = 0x0A,
         //
+        VersionCommandClassGet = 0x13,
+        VersionCommandClassReport = 0x14,
+        //
         ThermostatSetPointSet = 0x01,
         ThermostatSetPointGet = 0x02,
         ThermostatSetPointReport = 0x03,

--- a/ZWaveLib/Enums/EventParameter.cs
+++ b/ZWaveLib/Enums/EventParameter.cs
@@ -51,6 +51,7 @@ namespace ZWaveLib
         WakeUpInterval,
         WakeUpNotify,
         Association,
+        VersionCommandClass,
         Battery,
         NodeInfo,
         MultiinstanceSwitchBinaryCount,

--- a/ZWaveLib/Values/AlarmValue.cs
+++ b/ZWaveLib/Values/AlarmValue.cs
@@ -42,6 +42,11 @@ namespace ZWaveLib.Values
         HomeHealth
     }
 
+    /// <summary>
+    /// Enumerator for alarm value details. e.g., 0x16 corresponds with the action of 
+    /// an open door if the alarm AccessControl alarm type is set.
+    /// </summary>
+    /// 
     public enum ZWaveAlarmDetailType
     {
         Generic = 0x00,

--- a/ZWaveLib/Values/VersionCmdClassValue.cs
+++ b/ZWaveLib/Values/VersionCmdClassValue.cs
@@ -1,18 +1,18 @@
 ﻿/*
-    This file is part of HomeGenie Project source code.
+    This file is part of ZWaveLib Project source code.
 
-    HomeGenie is free software: you can redistribute it and/or modify
+    ZWaveLib is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    HomeGenie is distributed in the hope that it will be useful,
+    ZWaveLib is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with HomeGenie.  If not, see <http://www.gnu.org/licenses/>.  
+    along with ZWaveLib.  If not, see <http://www.gnu.org/licenses/>.  
 */
 
 /*

--- a/ZWaveLib/Values/VersionCmdClassValue.cs
+++ b/ZWaveLib/Values/VersionCmdClassValue.cs
@@ -1,0 +1,45 @@
+﻿/*
+    This file is part of HomeGenie Project source code.
+
+    HomeGenie is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    HomeGenie is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with HomeGenie.  If not, see <http://www.gnu.org/licenses/>.  
+*/
+
+/*
+*     Author: http://github.com/mdave
+*     Project Homepage: https://github.com/genielabs/zwave-lib-dotnet
+*/
+
+using System;
+using System.Collections;
+
+namespace ZWaveLib.Values
+{
+    public class VersionCmdClassValue
+    {
+        public CommandClass cmdClass;
+        public byte version;
+
+        public VersionCmdClassValue(CommandClass cmdClass, byte version)
+        {
+            this.cmdClass = cmdClass;
+            this.version = version;
+        }
+
+        public VersionCmdClassValue()
+        {
+            this.cmdClass = 0;
+            this.version = 0;
+        }
+    }
+}

--- a/ZWaveLib/ZWaveController.cs
+++ b/ZWaveLib/ZWaveController.cs
@@ -1340,6 +1340,7 @@ namespace ZWaveLib
         public Dictionary<CommandClass, byte> CommandClassVersions { get; internal set; }
 
         // Get around the fact that Dictionaries aren't supported by XmlSerialize
+        // Solution found in: http://stackoverflow.com/questions/495647/serialize-class-containing-dictionary-member
         public class SerializeableKeyValue<T1,T2>
         {
             public T1 Key { get; set; }

--- a/ZWaveLib/ZWaveController.cs
+++ b/ZWaveLib/ZWaveController.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Xml.Serialization;
 
+using ZWaveLib.Values;
 using ZWaveLib.CommandClasses;
 using SerialPortLib;
 using System.Diagnostics;
@@ -191,7 +192,6 @@ namespace ZWaveLib
         /// </summary>
         /// <returns>The message.</returns>
         /// <param name="message">Message.</param>
-        /// <param name="enableCallback">If set to <c>true</c> enable callback.</param>
         public bool SendMessage(ZWaveMessage message)
         {
             #region Debug 
@@ -1030,6 +1030,22 @@ namespace ZWaveLib
                 // we just send other events and save the node data
                 NodeInformationFrameDone(node);
             }
+            else if (eventData.Parameter == EventParameter.VersionCommandClass)
+            {
+                VersionCmdClassValue value = (VersionCmdClassValue)eventData.Value;
+
+                // Unsupported command class
+                if (!node.SupportCommandClass(value.cmdClass))
+                {
+                    return;
+                }
+
+                node.CommandClassVersions[value.cmdClass] = value.version;
+                SaveNodesConfig();
+
+                return;
+            }
+
             // Route node event
             OnNodeUpdated(new NodeUpdatedEventArgs(eventData.Node.Id, eventData));
         }
@@ -1162,6 +1178,7 @@ namespace ZWaveLib
                     newNode.NodeInformationFrame = node.NodeInformationFrame;
                     newNode.SecuredNodeInformationFrame = node.SecuredNodeInformationFrame;
                     Security.GetSecurityData(newNode).SetPrivateNetworkKey(node.DevicePrivateNetworkKey);
+                    newNode.CommandClassVersions = node.CommandClassVersions;
                     nodes.Add(newNode);
                 }
                 reader.Close();
@@ -1185,7 +1202,8 @@ namespace ZWaveLib
                         NodeId = nodes[n].Id,
                         NodeInformationFrame = nodes[n].NodeInformationFrame,
                         SecuredNodeInformationFrame = nodes[n].SecuredNodeInformationFrame,
-                        DevicePrivateNetworkKey = Security.GetSecurityData(nodes[n]).GetPrivateNetworkKey()
+                        DevicePrivateNetworkKey = Security.GetSecurityData(nodes[n]).GetPrivateNetworkKey(),
+                        CommandClassVersions = nodes[n].CommandClassVersions
                     });
                 }
             }
@@ -1217,6 +1235,16 @@ namespace ZWaveLib
             // TODO: deprecate the WakeUpNotify event?
             OnNodeUpdated(new NodeUpdatedEventArgs(znode.Id, new NodeEvent(znode, EventParameter.WakeUpNotify, "1", 0)));
             SaveNodesConfig();
+
+            // For nodes that support version command class, query each one for its version.
+            if (znode.SupportCommandClass(CommandClass.Version))
+            {
+                // Compile a list of all of our command class IDs
+                foreach (var cmdClass in znode.SupportedCommandClasses)
+                {
+                    ZWaveLib.CommandClasses.Version.Get(znode, cmdClass);
+                }
+            }
         }
 
         #endregion
@@ -1303,6 +1331,39 @@ namespace ZWaveLib
         /// </summary>
         /// <value>The device private network key.</value>
         public byte[] DevicePrivateNetworkKey { get; internal set; }
-    }
 
+        /// <summary>
+        /// Gets or sets the command class versions.
+        /// </summary>
+        /// <value>The command class versions.</value>
+        [XmlIgnore]
+        public Dictionary<CommandClass, byte> CommandClassVersions { get; internal set; }
+
+        // Get around the fact that Dictionaries aren't supported by XmlSerialize
+        public class SerializeableKeyValue<T1,T2>
+        {
+            public T1 Key { get; set; }
+            public T2 Value { get; set; }
+        }
+        public SerializeableKeyValue<CommandClass, byte>[] CommandClassSerializable
+        {
+            get
+            {
+                var list = new List<SerializeableKeyValue<CommandClass, byte>>();
+                if (CommandClassVersions != null)
+                {
+                    list.AddRange(CommandClassVersions.Keys.Select(key => new SerializeableKeyValue<CommandClass, byte>() { Key = key, Value = CommandClassVersions[key] }));
+                }
+                return list.ToArray();
+            }
+            set
+            {
+                CommandClassVersions = new Dictionary<CommandClass, byte>();
+                foreach (var item in value)
+                {
+                    CommandClassVersions.Add(item.Key, item.Value);
+                }
+            }
+        }
+    }
 }

--- a/ZWaveLib/ZWaveLib.csproj
+++ b/ZWaveLib/ZWaveLib.csproj
@@ -92,6 +92,8 @@
     <Compile Include="Enums\EventParameter.cs" />
     <Compile Include="Enums\OperationStatus.cs" />
     <Compile Include="ZWaveController.cs" />
+    <Compile Include="CommandClasses\Version.cs" />
+    <Compile Include="Values\VersionCmdClassValue.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/ZWaveLib/ZWaveNode.cs
+++ b/ZWaveLib/ZWaveNode.cs
@@ -112,6 +112,11 @@ namespace ZWaveLib
         /// </summary>
         public event NodeUpdatedEventHandler NodeUpdated;
 
+        /// <summary>
+        /// Dictionary mapping supported command classes to versions.
+        /// </summary>
+        public Dictionary<CommandClass, byte> CommandClassVersions { get; internal set; }
+
         #endregion
 
         #region Lifecycle
@@ -126,6 +131,7 @@ namespace ZWaveLib
             this.controller = controller;
             Id = nodeId;
             Data = new Dictionary<string, object>();
+            CommandClassVersions = new Dictionary<CommandClass, byte>();
             NodeInformationFrame = new byte[]{};
             SecuredNodeInformationFrame = new byte[]{};
         }
@@ -142,6 +148,7 @@ namespace ZWaveLib
             Id = nodeId;
             GenericClass = genericType;
             Data = new Dictionary<string, object>();
+            CommandClassVersions = new Dictionary<CommandClass, byte>();
             NodeInformationFrame = new byte[]{};
             SecuredNodeInformationFrame = new byte[]{};
         }
@@ -216,6 +223,23 @@ namespace ZWaveLib
                 isSecured = (Array.IndexOf(SecuredNodeInformationFrame, (byte)commandClass) >= 0);
             }
             return isSecured;
+        }
+
+        /// <summary>
+        /// Determines the version of the specified command class.
+        /// </summary>
+        /// <returns>The command class version, or 0 if it is not found.</returns>
+        /// <param name="cmdClass">Command class to query</param>
+        public byte GetCmdClassVersion(CommandClass cmdClass)
+        {
+            if (CommandClassVersions.ContainsKey(cmdClass))
+            {
+                return CommandClassVersions[cmdClass];
+            }
+            else
+            {
+                return 0;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds support for the version command class, so that ZWaveLib is capable of processing additional detail from later versions. Versions are stored inside the node configuration file alongside the node information to make them more resilient to restarts (particularly for battery operated devices). Versions are also reported in the `Test.ZWave` utility.

As a first go at using this in some of the command classes, I have updated the SensorBinary and Alarm classes to support V2 reports. Note this is only partial, since V2 also allows queries for the device's sensor/alarm capabilities (and thereby their current state), which I have not implemented.

The alarm v2 changes might also need a bit more thinking about. There are standard values (I found a pretty complete list at http://220.135.186.178/zwave/example/ALARM/index.html) but these don't really translate well through the SensorGeneric event parameter. For example, my door sensor reports 0x16 and 0x17 (open and closed) and 0x03 (tamper) which get misinterpreted by HomeGenie. My solution was to map these values to something more sensible (i.e. 0 for closed, 1 for open) and trigger the closest-looking EventParameter. I've added the aforementioned ones that I was able to test, but there are a bunch more that could theoretically be put in.
