### PR TITLE
Additional options for Z-Wave controller

### DIFF
--- a/ZWaveLib/Enums/OperationStatus.cs
+++ b/ZWaveLib/Enums/OperationStatus.cs
@@ -50,6 +50,13 @@ namespace ZWaveLib
         DiscoveryError = 0x0203
     }
 
+    public enum HealStatus : uint
+    {
+        HealStart = 0x0201,
+        HealEnd = 0x0202,
+        HealError = 0x0203
+    }
+
     public enum NodeQueryStatus : uint
     {
         NodeAdded = 0xFF01,
@@ -77,7 +84,7 @@ namespace ZWaveLib
     public enum NeighborsUpdateStatus : byte
     {
         None = 0x00,
-        NeighborsUpdateStared = 0x21,
+        NeighborsUpdateStarted = 0x21,
         NeighborsUpdateDone = 0x22,
         NeighborsUpdateFailed = 0x23
     }

--- a/ZWaveLib/Events.cs
+++ b/ZWaveLib/Events.cs
@@ -82,6 +82,16 @@ namespace ZWaveLib
         }
     }
 
+    public class HealProgressEventArgs
+    {
+        public readonly HealStatus Status;
+
+        public HealProgressEventArgs(HealStatus status)
+        {
+            this.Status = status;
+        }
+    }
+
     public class MessageReceivedEventArgs
     {
         public readonly ZWaveMessage Message;

--- a/ZWaveLib/ZWaveController.cs
+++ b/ZWaveLib/ZWaveController.cs
@@ -47,6 +47,8 @@ namespace ZWaveLib
 
         private SerialPortInput serialPort;
         private string portName = "";
+        private int commandDelay = 0;
+        private DateTime lastCommand = DateTime.Now;
 
         private ManualResetEvent sendMessageAck = new ManualResetEvent(false);
         private bool busyReceiving = false;
@@ -189,6 +191,32 @@ namespace ZWaveLib
             {
                 portName = value;
                 serialPort.SetPort(value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the amount of command delay.
+        /// </summary>
+        /// <value>The length of the delay in ms.</value>
+        public int CommandDelay
+        {
+            get { return commandDelay; }
+            set
+            {
+                commandDelay = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the wait boolean.
+        /// </summary>
+        /// <value>The current wait state.</value>
+        public DateTime LastCommand
+        {
+            get { return lastCommand; }
+            set
+            {
+                lastCommand = value;
             }
         }
 
@@ -374,6 +402,7 @@ namespace ZWaveLib
                         zn.OnNodeUpdated(new NodeEvent(zn, EventParameter.ManufacturerSpecific, zn.ManufacturerSpecific, 0));
                     // Raise the node updated event
                     UpdateOperationProgress(zn.Id, NodeQueryStatus.NodeUpdated);
+                    System.Threading.Thread.Sleep(commandDelay);
                 }
                 discoveryRunning = false;
                 if (!discoveryError)

--- a/ZWaveLib/ZWaveController.cs
+++ b/ZWaveLib/ZWaveController.cs
@@ -49,6 +49,7 @@ namespace ZWaveLib
         private string portName = "";
         private int commandDelay = 0;
         private DateTime lastCommand = DateTime.Now;
+        private bool startupDiscovery = true;
 
         private ManualResetEvent sendMessageAck = new ManualResetEvent(false);
         private bool busyReceiving = false;
@@ -217,6 +218,19 @@ namespace ZWaveLib
             set
             {
                 lastCommand = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the startup discovery boolean.
+        /// </summary>
+        /// <value>The startup discovery boolean.</value>
+        public bool StartupDiscovery
+        {
+            get { return startupDiscovery; }
+            set
+            {
+                startupDiscovery = value;
             }
         }
 

--- a/ZWaveLib/ZWaveController.cs
+++ b/ZWaveLib/ZWaveController.cs
@@ -54,6 +54,7 @@ namespace ZWaveLib
         private ManualResetEvent sendMessageAck = new ManualResetEvent(false);
         private bool busyReceiving = false;
         private bool discoveryRunning = false;
+        private bool healRunning = false;
 
         private ZWaveMessage pendingRequest;
         private QueryStage currentStage;
@@ -91,9 +92,19 @@ namespace ZWaveLib
         public delegate void DiscoveryProgressEventHandler(object sender, DiscoveryProgressEventArgs args);
 
         /// <summary>
+        /// Heal progress event handler.
+        /// </summary>
+        public delegate void HealProgressEventHandler(object sender, HealProgressEventArgs args);
+
+        /// <summary>
         /// Occurs during discovery process.
         /// </summary>
         public event DiscoveryProgressEventHandler DiscoveryProgress;
+
+        /// <summary>
+        /// Occurs during heal process.
+        /// </summary>
+        public event HealProgressEventHandler HealProgress;
 
         /// <summary>
         /// Node operation progress event handler.
@@ -435,6 +446,43 @@ namespace ZWaveLib
             }
         }
 
+        /// <summary>
+        /// Iterate through the nodes and performa a heal on each one
+        /// </summary>
+        public void HealNetwork()
+        {
+            // A full network heal can be a long operation, so we ensure that only one instance of this is running
+            if (!healRunning)
+            {
+                healRunning = true;
+                bool healError = false;
+                OnHealProgress(new HealProgressEventArgs(HealStatus.HealStart));
+                foreach (ZWaveNode zn in nodeList)
+                {
+                    if (controllerStatus != ControllerStatus.Ready || !serialPort.IsConnected)
+                    {
+                        healError = true;
+                        break;
+                    }
+                    Utility.logger.Trace("Healing node {0}", zn.Id);
+                    RequestNeighborsUpdateOptions(zn.Id);
+                    RequestNeighborsUpdate(zn.Id);
+                    GetNeighborsRoutingInfo(zn.Id);
+                    System.Threading.Thread.Sleep(commandDelay);
+                }
+                healRunning = false;
+                if (healError)
+                {
+                    OnHealProgress(new HealProgressEventArgs(HealStatus.HealError));
+                }
+                OnHealProgress(new HealProgressEventArgs(HealStatus.HealEnd));
+            }
+            else
+            {
+                Utility.logger.Warn("Heal already running");
+            }
+        }
+
         public void GetNodeCcsVersion(ZWaveNode zn)
         {
             // If node support version command class, query each one for its version.
@@ -702,6 +750,7 @@ namespace ZWaveLib
                         {
                             msg.ResendCount++;
                             Utility.logger.Warn("Could not deliver message to Node {0} (CallbackId={1}, Retry={2})", msg.NodeId, msg.CallbackId.ToString("X2"), msg.ResendCount);
+                            System.Threading.Thread.Sleep(commandDelay > 250 ? commandDelay : 250);
                         }
                         msg.sentAck.Set();
                     
@@ -878,7 +927,7 @@ namespace ZWaveLib
                     switch (neighborUpdateStatus)
                     {
 
-                    case NeighborsUpdateStatus.NeighborsUpdateStared:
+                    case NeighborsUpdateStatus.NeighborsUpdateStarted:
 
                         UpdateOperationProgress(msg.NodeId, NodeQueryStatus.NeighborUpdateStarted);
                         break;
@@ -1389,6 +1438,17 @@ namespace ZWaveLib
             Utility.logger.Debug(args.Status);
             if (DiscoveryProgress != null)
                 DiscoveryProgress(this, args);
+        }
+
+        /// <summary>
+        /// Raises the heal progress event.
+        /// </summary>
+        /// <param name="args">Arguments.</param>
+        protected virtual void OnHealProgress(HealProgressEventArgs args)
+        {
+            Utility.logger.Debug(args.Status);
+            if (HealProgress != null)
+                HealProgress(this, args);
         }
 
         /// <summary>


### PR DESCRIPTION
I was having some timing problems with my controller, and found that adding a small delay between commands helped considerably. This will vary from configuration to configuration, so it's selectable in the ZWave Interface Options page. Also, the controller discovery on restart locks the system up until discovery is complete, which takes a considerable while on 50+ devices, so I made it optional.
