### PR TITLE
Added Clock command class

### DIFF
--- a/ZWaveLib/CommandClasses/Clock.cs
+++ b/ZWaveLib/CommandClasses/Clock.cs
@@ -1,0 +1,69 @@
+/*
+    This file is part of ZWaveLib Project source code.
+
+    ZWaveLib is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    ZWaveLib is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with ZWaveLib.  If not, see <http://www.gnu.org/licenses/>.  
+*/
+
+/*
+ *     Author: Generoso Martello <gene@homegenie.it>
+ *             Ben Voss
+ *     Project Homepage: https://github.com/genielabs/zwave-lib-dotnet
+ */
+
+using System.Collections.Generic;
+
+namespace ZWaveLib.CommandClasses
+{
+    public class Clock : ICommandClass
+    {
+        public CommandClass GetClassId()
+        {
+            return CommandClass.Clock;
+        }
+
+        public NodeEvent GetEvent(ZWaveNode node, byte[] message)
+        {
+            NodeEvent nodeEvent = null;
+            byte cmdType = message[1];
+            if ((message.Length > 0) && (cmdType == (byte)Command.ClockReport))
+            {
+                var clockValue = ClockValue.Parse (message);
+                nodeEvent = new NodeEvent(node, EventParameter.Clock, clockValue, 0);
+            }
+            return nodeEvent;
+        }
+
+        public static ZWaveMessage Set(ZWaveNode node, ClockValue value)
+        {
+            List<byte> message = new List<byte> ();
+            message.AddRange (new byte [] {
+                (byte)CommandClass.Clock,
+                (byte)Command.ClockSet
+            });
+            message.AddRange (value.GetValueBytes ());
+
+            return node.SendDataRequest(message.ToArray());
+        }
+
+        public static ZWaveMessage Get(ZWaveNode node)
+        {
+            return node.SendDataRequest(new byte[] { 
+                (byte)CommandClass.Clock, 
+                (byte)Command.ClockGet 
+            });
+        }
+
+    }
+}
+

--- a/ZWaveLib/Enums/Command.cs
+++ b/ZWaveLib/Enums/Command.cs
@@ -134,7 +134,12 @@ namespace ZWaveLib
         DoorLockReport = 0x03,
         DoorLockConfigurationSet = 0x04,
         DoorLockConfigurationGet = 0x05,
-        DoorLockConfigurationReport = 0x06
+        DoorLockConfigurationReport = 0x06,
+        //
+        ClockVersion = 0x01,
+        ClockGet = 0x05,
+        ClockSet = 0x04,
+        ClockReport = 0x06,
     }
 
 }

--- a/ZWaveLib/Enums/EventParameter.cs
+++ b/ZWaveLib/Enums/EventParameter.cs
@@ -77,7 +77,8 @@ namespace ZWaveLib
         SecurityDecriptedMessage,
         SecurityGeneratedKey,
         DoorLockStatus,
-        RoutingInfo
+        RoutingInfo,
+        Clock
     }
 
 }

--- a/ZWaveLib/Values/ClockValue.cs
+++ b/ZWaveLib/Values/ClockValue.cs
@@ -1,0 +1,62 @@
+﻿/*
+    This file is part of ZWaveLib Project source code.
+
+    ZWaveLib is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    ZWaveLib is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with ZWaveLib.  If not, see <http://www.gnu.org/licenses/>.  
+*/
+
+/*
+ *     Author: Generoso Martello <gene@homegenie.it>
+ *             Ben Voss
+ *     Project Homepage: https://github.com/genielabs/zwave-lib-dotnet
+ */
+
+using System;
+
+namespace ZWaveLib
+{
+    public enum Weekday
+    {
+        None = 0,
+        Monday = 1,
+        Tuesday = 2,
+        Wednesday = 3,
+        Thursday = 4,
+        Friday = 5,
+        Saturday = 6,
+        Sunday = 7
+    }
+
+    public class ClockValue
+    {
+        public Weekday Weekday { get; set; }
+        public int Hour { get; set;}
+        public int Minute { get; set; }
+
+        public static ClockValue Parse (byte [] message)
+        {
+            var value = new ClockValue ();
+
+            value.Weekday = (Weekday)(message [2] >> 5);
+            value.Hour = message [2] & 0x1f;
+            value.Minute = message [3];
+
+            return value;
+        }
+
+        public byte [] GetValueBytes ()
+        {
+            return new byte [] { (byte)((int)Weekday << 5 | Hour), (byte)Minute };
+        }
+    }
+}

--- a/ZWaveLib/ZWaveLib.csproj
+++ b/ZWaveLib/ZWaveLib.csproj
@@ -96,6 +96,8 @@
     <Compile Include="Values\VersionValue.cs" />
     <Compile Include="Enums\Message.cs" />
     <Compile Include="Values\WakeUpStatus.cs" />
+    <Compile Include="CommandClasses\Clock.cs" />
+    <Compile Include="Values\ClockValue.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
This implements the COMMAND_CLASS_CLOCK functionality as described in section 4.32 of the z-wave spec.  It has been tested on a Popp POPE010101 Z-Wave Radiator Thermostat