### PR TITLE
simple command line client

### DIFF
--- a/Command.ZWave/Command.ZWave.csproj
+++ b/Command.ZWave/Command.ZWave.csproj
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{30BFF64C-74E5-4C94-B327-1E3CAE3AFF22}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Command.ZWave</RootNamespace>
+    <AssemblyName>Command.ZWave</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <ReleaseVersion>1.0</ReleaseVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Externalconsole>true</Externalconsole>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Externalconsole>true</Externalconsole>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="NLog">
+      <HintPath>..\packages\NLog.4.1.0\lib\net45\NLog.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\ZWaveLib\ZWaveLib.csproj">
+      <Project>{06995CE8-149B-42FA-B345-FB11C4D6E180}</Project>
+      <Name>ZWaveLib</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+</Project>

--- a/Command.ZWave/Program.cs
+++ b/Command.ZWave/Program.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Mono.CSharp;
+
+using NLog;
+
+namespace Command.ZWave
+{
+    public class ForSharingWithEvaluator {
+        public static ZWaveLib.ZWaveController controllerForSharingToEvaluator;
+    }
+    internal class MainClass
+    {
+        internal static Logger logger;
+
+        private static String getConfVariable(String key, String value) {
+            var fromEnv = Environment.GetEnvironmentVariable (key);
+            return (fromEnv != null) ? fromEnv : value;
+        }
+
+        public static void Main (string[] args)
+        {
+            var config = new NLog.Config.LoggingConfiguration ();
+            var target = new NLog.Targets.ConsoleTarget ();
+            target.Layout = @"${date:format=HH\:mm\:ss} ${message}";
+            config.LoggingRules.Add (new NLog.Config.LoggingRule ("*", LogLevel.FromString(getConfVariable("ZWAVE_LOG_LEVEL", LogLevel.Info.Name)), target));
+            LogManager.Configuration = config;
+            logger = LogManager.GetCurrentClassLogger ();
+
+            var portName = getConfVariable("ZWAVE_SERIAL_PORT", "/dev/ttyUSB0");
+            logger.Info("started ZWave.Command with port {0} and command line: {1}", portName, String.Join(" ", args));
+            var controller = new ZWaveLib.ZWaveController (portName);
+            controller.ControllerStatusChanged += (c, ev) => {
+                logger.Trace ("ControllerStatusChanged status {0}: {1}", controller.Status, ev.Status);
+                switch (ev.Status) {
+                case ZWaveLib.ControllerStatus.Connected:
+                    controller.Initialize ();
+                    break;
+                case ZWaveLib.ControllerStatus.Ready:
+                    controller.Discovery ();
+                    logger.Info ("finished discovery with {0} nodes: {1}", controller.Nodes.ToArray ().Length, String.Join (", ", from node in controller.Nodes
+                        select node.Id));
+
+                    DiscoveryDone (controller);
+                    break;
+                case ZWaveLib.ControllerStatus.Error:
+                    logger.Error("controller ControllerStatusChanged to Error: {0} - exiting", controller);
+                    Environment.Exit(17);
+                    break;
+                }
+            };
+
+            controller.DiscoveryProgress += (c, ev) => {
+                logger.Trace ("DiscoverProgress status {0}: {1} {2}", controller.Status, ev.GetType (), ev.Status);
+            };
+            controller.NodeOperationProgress += (c, ev) => {
+                logger.Trace ("NodeOperationProgress status {0}: node {1} now {2}", controller.Status, ev.NodeId, ev.Status);
+            };
+            controller.Connect ();
+        }
+
+
+        private static void DiscoveryDone (ZWaveLib.ZWaveController controller)
+        {
+            var messages = new List<ZWaveLib.ZWaveMessage> ();
+
+            controller.NodeUpdated += (c, ev) => {
+                logger.Info ("NodeUpdated {0} {1} {2} {3}", ev.NodeId, ev.GetType(), ev.Event.Parameter, ev.Event.Value);
+            };
+
+            foreach (var node in controller.Nodes) {
+                logger.Info ("node {0}: manufacturer {1} type {2} product {3} - supported command classes {4}",
+                    node.Id, 
+                    node.ManufacturerSpecific.ManufacturerId,
+                    node.ManufacturerSpecific.TypeId,
+                    node.ManufacturerSpecific.ProductId,
+                    String.Join (", ", from klass in node.CommandClasses
+                        select klass.CommandClass) 
+                );
+            }
+
+            var settings = new CompilerSettings ();
+            settings.LoadDefaultReferences = true;
+            var evaluator = new Mono.CSharp.Evaluator (new CompilerContext(settings, new ConsoleReportPrinter()));
+            evaluator.ReferenceAssembly (controller.GetType ().Assembly);
+
+            evaluator.ReferenceAssembly (System.Reflection.Assembly.GetExecutingAssembly());
+
+            foreach (var ns in new List<String> {"ZWaveLib.CommandClasses","ZWaveLib.Values","System","System.Threading","System.Linq"}) {
+                evaluator.Run(String.Format("using {0};", ns));
+            }
+
+            ForSharingWithEvaluator.controllerForSharingToEvaluator = controller;
+            evaluator.Run ("var controller = Command.ZWave.ForSharingWithEvaluator.controllerForSharingToEvaluator;");
+            foreach (var node in controller.Nodes) {
+                evaluator.Run (String.Format("var node{0} = controller.GetNode({0});",node.Id));
+            }
+
+
+            foreach (var arg in Environment.GetCommandLineArgs().Skip(1)) {
+                try {
+                    logger.Info("evaluating '{0}'", arg);
+                    Object result;
+                    bool resultSet;
+                    evaluator.Evaluate (arg + ";", out result, out resultSet);
+                    if (resultSet && result is ZWaveLib.ZWaveMessage) {
+                        messages.Add((ZWaveLib.ZWaveMessage)result);
+                    }
+                } catch (Exception ex) {
+                    logger.Error (ex, "error evaluating '{0}'", arg);
+                }
+            }
+            foreach (var message in messages) {
+                message.Wait ();
+            }
+            Environment.Exit (0);
+
+        }
+    }
+}

--- a/Command.ZWave/Properties/AssemblyInfo.cs
+++ b/Command.ZWave/Properties/AssemblyInfo.cs
@@ -1,0 +1,27 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes.
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle("Command.ZWave")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("john")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly,
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]
+

--- a/ZWaveLib.sln
+++ b/ZWaveLib.sln
@@ -1,9 +1,11 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZWaveLib", "ZWaveLib\ZWaveLib.csproj", "{06995CE8-149B-42FA-B345-FB11C4D6E180}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test.ZWave", "Test.ZWave\Test.ZWave.csproj", "{528CDF2E-4FFB-4154-9115-36590F380342}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Command.ZWave", "Command.ZWave\Command.ZWave.csproj", "{30BFF64C-74E5-4C94-B327-1E3CAE3AFF22}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{06995CE8-149B-42FA-B345-FB11C4D6E180}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{06995CE8-149B-42FA-B345-FB11C4D6E180}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{06995CE8-149B-42FA-B345-FB11C4D6E180}.Release|Any CPU.Build.0 = Release|Any CPU
+		{30BFF64C-74E5-4C94-B327-1E3CAE3AFF22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{30BFF64C-74E5-4C94-B327-1E3CAE3AFF22}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{30BFF64C-74E5-4C94-B327-1E3CAE3AFF22}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{30BFF64C-74E5-4C94-B327-1E3CAE3AFF22}.Release|Any CPU.Build.0 = Release|Any CPU
 		{528CDF2E-4FFB-4154-9115-36590F380342}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{528CDF2E-4FFB-4154-9115-36590F380342}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{528CDF2E-4FFB-4154-9115-36590F380342}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/ZWaveLib/ZWaveController.cs
+++ b/ZWaveLib/ZWaveController.cs
@@ -182,7 +182,17 @@ namespace ZWaveLib
         public void Connect()
         {
             LoadNodesConfig();
-            new Thread(() => { serialPort.Connect(); }).Start();
+
+            new Thread(() =>
+            { 
+                if (!serialPort.Connect())
+                {
+                    Utility.logger.Error("Failed to connect to serial port {0}", serialPort);
+                    OnControllerStatusChanged(new ControllerStatusEventArgs(ControllerStatus.Error));
+                } else {
+                    Utility.logger.Trace("Connected to serial port {0}", serialPort);
+                }
+            }).Start();
         }
 
         /// <summary>
@@ -1379,6 +1389,7 @@ namespace ZWaveLib
 
         private void SerialPort_ConnectionStatusChanged(object sender, ConnectionStatusChangedEventArgs args)
         {
+            Utility.logger.Trace("SerialPort_ConnectionStatusChanged {0} Connected {1}", sender, args.Connected);
             var status = args.Connected ? ControllerStatus.Connected : ControllerStatus.Disconnected;
             serialBuffer = null;
             lastMessage = null;

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <repositories>
+  <repository path="../Command.ZWave/packages.config" />
   <repository path="../Test.ZWave/packages.config" />
   <repository path="../ZWaveLib/packages.config" />
 </repositories>


### PR DESCRIPTION
This simple command line client makes it easy to activate switches and view status for all the supported command classes in zwave-ilb-dotnet

For example, to turn off the binary switch at the third address

ZWaveCommandLine.exe 'SwitchBinary.Set(node3, 0)' 

Would love to know a better way to integrate this into your library!