### PR TITLE
Climate control schedule commands

### DIFF
--- a/ZWaveLib/CommandClasses/ClimateControlSchedule.cs
+++ b/ZWaveLib/CommandClasses/ClimateControlSchedule.cs
@@ -1,0 +1,109 @@
+﻿/*
+    This file is part of ZWaveLib Project source code.
+
+    ZWaveLib is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    ZWaveLib is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with ZWaveLib.  If not, see <http://www.gnu.org/licenses/>.  
+*/
+
+/*
+ *     Author: Generoso Martello <gene@homegenie.it>
+ *             Ben Voss
+ *     Project Homepage: https://github.com/genielabs/zwave-lib-dotnet
+ */
+
+using System.Collections.Generic;
+
+namespace ZWaveLib.CommandClasses
+{
+    public class ClimateControlSchedule : ICommandClass
+    {
+        public CommandClass GetClassId ()
+        {
+            return CommandClass.ClimateControlSchedule;
+        }
+
+        public NodeEvent GetEvent (ZWaveNode node, byte [] message)
+        {
+            if (message.Length == 0) {
+                return null;
+            }
+
+            byte cmdType = message [1];
+
+            if (cmdType == (byte)Command.ScheduleReport) {
+                var climateControlScheduleValue = ClimateControlScheduleValue.Parse (message);
+                return new NodeEvent (node, EventParameter.ClimateControlSchedule, climateControlScheduleValue, 0);
+            }
+
+            if (cmdType == (byte)Command.ScheduleChangedReport) {
+                return new NodeEvent (node, EventParameter.ClimateControlScheduleChanged, message[2], 0);
+            }
+
+            if (cmdType == (byte)Command.ScheduleChangedReport) {
+                var climateControlScheduleOverrideValue = ClimateControlScheduleOverrideValue.Parse (message);
+                return new NodeEvent (node, EventParameter.ClimateControlScheduleOverride, climateControlScheduleOverrideValue, 0);
+            }
+
+            return null;
+        }
+
+        public static ZWaveMessage Set (ZWaveNode node, ClimateControlScheduleValue value)
+        {
+            var message = new List<byte> ();
+            message.AddRange (new byte [] {
+                (byte)CommandClass.ClimateControlSchedule,
+                (byte)Command.ScheduleSet
+            });
+            message.AddRange (value.GetValueBytes ());
+
+            return node.SendDataRequest (message.ToArray ());
+        }
+
+        public static ZWaveMessage Get (ZWaveNode node, Weekday weekday)
+        {
+            return node.SendDataRequest (new byte [] {
+                (byte)CommandClass.ClimateControlSchedule,
+                (byte)Command.ScheduleGet,
+                (byte)weekday
+            });
+        }
+
+        public static ZWaveMessage ChangedGet (ZWaveNode node)
+        {
+            return node.SendDataRequest (new byte [] {
+                (byte)CommandClass.ClimateControlSchedule,
+                (byte)Command.ScheduleChangedGet
+            });
+        }
+
+        public static ZWaveMessage OverrideSet (ZWaveNode node, ClimateControlScheduleOverrideValue scheduleOverride)
+        {
+            var message = new List<byte> ();
+            message.AddRange (new byte [] {
+                (byte)CommandClass.ClimateControlSchedule,
+                (byte)Command.ScheduleOverrideSet,
+            });
+            message.AddRange (scheduleOverride.GetValueBytes ());
+
+            return node.SendDataRequest (message.ToArray ());
+        }
+
+        public static ZWaveMessage OverrideGet (ZWaveNode node)
+        {
+            return node.SendDataRequest (new byte [] {
+                (byte)CommandClass.ClimateControlSchedule,
+                (byte)Command.ScheduleOverrideGet
+            });
+        }
+    }
+}

--- a/ZWaveLib/Enums/Command.cs
+++ b/ZWaveLib/Enums/Command.cs
@@ -160,7 +160,16 @@ namespace ZWaveLib
         IrrigationValveTableReport = 0x10, // IRRIGATION_VALVE_TABLE_REPORT
         IrrigationValveTableRun = 0x11, // IRRIGATION_VALVE_TABLE_RUN
         IrrigationSystemShutoff = 0x12, // IRRIGATION_SYSTEM_SHUTOFF
-}
 
+        // Climate Control Schedule command class commands
+        ScheduleSet = 0x01,
+        ScheduleGet = 0x02,
+        ScheduleReport = 0x03,
+        ScheduleChangedGet = 0x04,
+        ScheduleChangedReport = 0x05,
+        ScheduleOverrideSet = 0x06,
+        ScheduleOverrideGet = 0x07,
+        ScheduleOverrideReport = 0x08
+    }
 }
 

--- a/ZWaveLib/Enums/CommandClass.cs
+++ b/ZWaveLib/Enums/CommandClass.cs
@@ -46,6 +46,7 @@ namespace ZWaveLib
         ThermostatSetPoint = 0x43,
         ThermostatFanMode = 0x44,
         ThermostatFanState = 0x45,
+        ClimateControlSchedule = 0x46,
         ThermostatSetBack = 0x47,
         //
         Crc16Encapsulated = 0x56,

--- a/ZWaveLib/Enums/EventParameter.cs
+++ b/ZWaveLib/Enums/EventParameter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
     This file is part of ZWaveLib Project source code.
 
     ZWaveLib is free software: you can redistribute it and/or modify
@@ -88,7 +88,11 @@ namespace ZWaveLib
         IrrigationValveTableReport,
 
         WaterFlow,
-        WaterPressure
+        WaterPressure,
+
+        ClimateControlSchedule,
+        ClimateControlScheduleChanged,
+        ClimateControlScheduleOverride
     }
 
 }

--- a/ZWaveLib/Enums/OverrideType.cs
+++ b/ZWaveLib/Enums/OverrideType.cs
@@ -1,0 +1,35 @@
+﻿/*
+    This file is part of ZWaveLib Project source code.
+
+    ZWaveLib is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    ZWaveLib is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with ZWaveLib.  If not, see <http://www.gnu.org/licenses/>.  
+*/
+
+/*
+ *     Author: Generoso Martello <gene@homegenie.it>
+ *             Ben Voss
+ *     Project Homepage: https://github.com/genielabs/zwave-lib-dotnet
+ */
+
+using System;
+
+namespace ZWaveLib
+{
+    [Flags]
+    public enum OverrideType
+    {
+        None = 0,
+        Temporary = 1,
+        Permenant = 2
+    }
+}

--- a/ZWaveLib/Values/ClimateControlScheduleOverrideValue.cs
+++ b/ZWaveLib/Values/ClimateControlScheduleOverrideValue.cs
@@ -21,47 +21,36 @@
  *     Project Homepage: https://github.com/genielabs/zwave-lib-dotnet
  */
 
-using System;
-
 namespace ZWaveLib
 {
-    public enum Weekday
+    public class ClimateControlScheduleOverrideValue
     {
-        None = 0,
-        Monday = 1,
-        Tuesday = 2,
-        Wednesday = 3,
-        Thursday = 4,
-        Friday = 5,
-        Saturday = 6,
-        Sunday = 7
-    }
 
-    public class ClockValue
-    {
-        public Weekday Weekday { get; set; }
-        public int Hour { get; set;}
-        public int Minute { get; set; }
+        public OverrideType OverrideType { get; set; }
 
-        public static ClockValue Parse (byte [] message)
+        public ScheduleStateValue ScheduleState { get; set; }
+
+        public static ClimateControlScheduleOverrideValue Parse (byte [] bytes)
         {
-            var value = new ClockValue ();
+            var result = new ClimateControlScheduleOverrideValue ();
 
-            value.Weekday = (Weekday)(message [2] >> 5);
-            value.Hour = message [2] & 0x1f;
-            value.Minute = message [3];
+            result.OverrideType = (OverrideType)bytes [2];
+            result.ScheduleState = ScheduleStateValue.Parse (bytes [3]);
 
-            return value;
+            return result;
         }
 
         public byte [] GetValueBytes ()
         {
-            return new byte [] { (byte)((int)Weekday << 5 | Hour), (byte)Minute };
+            return new byte [] {
+                (byte)OverrideType,
+                ScheduleState.GetValueByte()
+            };
         }
 
         public override string ToString ()
         {
-            return string.Format ("[ClockValue: Weekday={0}, Hour={1}, Minute={2}]", Weekday, Hour, Minute);
+            return string.Format ("[ClimateControlScheduleOverrideValue: OverrideType={0}, ScheduleState={1}]", OverrideType, ScheduleState);
         }
     }
 }

--- a/ZWaveLib/Values/ClimateControlScheduleValue.cs
+++ b/ZWaveLib/Values/ClimateControlScheduleValue.cs
@@ -1,0 +1,86 @@
+﻿/*
+    This file is part of ZWaveLib Project source code.
+
+    ZWaveLib is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    ZWaveLib is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with ZWaveLib.  If not, see <http://www.gnu.org/licenses/>.  
+*/
+
+/*
+ *     Author: Generoso Martello <gene@homegenie.it>
+ *             Ben Voss
+ *     Project Homepage: https://github.com/genielabs/zwave-lib-dotnet
+ */
+
+using System.Text;
+using System.Collections.Generic;
+
+namespace ZWaveLib
+{
+    public class ClimateControlScheduleValue
+    {
+        private const int NumSwitchpoints = 9;
+
+        public ClimateControlScheduleValue ()
+        {
+            Switchpoints = new SwitchpointValue [NumSwitchpoints];
+            for (int i = 0; i < NumSwitchpoints; i++) {
+                Switchpoints [i] = new SwitchpointValue { State = new ScheduleStateValue { Unused = true } };
+            }
+        }
+
+        public Weekday Weekday { get; set; }
+
+        public SwitchpointValue[] Switchpoints { get; }
+
+        public byte [] GetValueBytes ()
+        {
+            var result = new List<byte> ();
+            result.Add ((byte)Weekday);
+
+            for (int i = 0; i < NumSwitchpoints; i++) {
+                result.AddRange (Switchpoints[i].GetValueBytes ());
+            }
+
+            return result.ToArray();
+        }
+
+        public static ClimateControlScheduleValue Parse (byte [] bytes) {
+            var result = new ClimateControlScheduleValue ();
+
+            result.Weekday = (Weekday)bytes [2];
+
+            for (int i = 0; i < NumSwitchpoints; i++) {
+                result.Switchpoints [i] = SwitchpointValue.Parse(bytes, i * 3 + 3);
+
+            }
+
+            return result;
+        }
+
+        public override string ToString ()
+        {
+            var builder = new StringBuilder ();
+            builder.Append("[ClimateControlScheduleValue: Weekday=");
+            builder.Append (Weekday);
+            builder.Append (", Switchpoints: [");
+
+            for (int i = 0; i < NumSwitchpoints; i++) {
+                builder.AppendLine().Append("   Switchpoint: ").Append(i).Append(" ").Append (Switchpoints [i]);
+            }
+
+            builder.Append ("]");
+
+            return builder.ToString ();
+        }
+    }
+}

--- a/ZWaveLib/Values/ScheduleStateValue.cs
+++ b/ZWaveLib/Values/ScheduleStateValue.cs
@@ -1,0 +1,90 @@
+﻿/*
+    This file is part of ZWaveLib Project source code.
+
+    ZWaveLib is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    ZWaveLib is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with ZWaveLib.  If not, see <http://www.gnu.org/licenses/>.  
+*/
+
+/*
+ *     Author: Generoso Martello <gene@homegenie.it>
+ *             Ben Voss
+ *     Project Homepage: https://github.com/genielabs/zwave-lib-dotnet
+ */
+
+namespace ZWaveLib
+{
+    public class ScheduleStateValue
+    {
+        /// <summary>
+        /// The setback in 1/10 degrees (Kelvin)
+        /// </summary>
+        /// <remarks>
+        ///     Example:
+        ///         0 = 0 degrees setback
+        ///         1 = 0.1 degrees is added to the setpoint
+        ///         2 = 0.2 degrees is added to the setpoint
+        ///         -1 = 0.1 degrees is subtracted from the setpoint
+        ///         -2 = 0.2 degrees is subtracted from the setpoint
+        /// 
+        ///     Null When the schedule state indicates FrostProtection, EntergySavingMode or is Unused.
+        /// </remarks>
+        /// <value>The setback.</value>
+        public int? Setback { get; set; }
+
+        public bool FrostProtectionMode { get; set; }
+
+        public bool EnergySavingMode { get; set; }
+
+        public bool Unused { get; set; }
+
+        public static ScheduleStateValue Parse (byte b)
+        {
+            var value = new ScheduleStateValue ();
+
+            var sb = (sbyte)b;
+            if (sb >= -128 && sb <= 120) {
+                value.Setback = sb;
+            } else if (b == 0x79) {
+                value.FrostProtectionMode = true;
+            } else if (b == 0x7a) {
+                value.EnergySavingMode = true;
+            } else if (b == 0x7f) {
+                value.Unused = true;
+            }
+
+            return value;
+        }
+
+        public byte GetValueByte ()
+        {
+            if (FrostProtectionMode) {
+                return 0x79;
+            } else if (EnergySavingMode) {
+                return 0x7a;
+            } else if (Unused) {
+                return 0x7f;
+            } else if (Setback >= -128 && Setback <= 120) {
+                return (byte)(sbyte)Setback;
+            }
+
+            // reserved
+            return 0x7e;
+        }
+
+        public override string ToString ()
+        {
+            return string.Format ("[ScheduleStateValue: Setback={0}, FrostProtectionMode={1}, EnergySavingMode={2}, Unused={3}]", Setback, FrostProtectionMode, EnergySavingMode, Unused);
+        }
+
+    }
+}

--- a/ZWaveLib/Values/SwitchpointValue.cs
+++ b/ZWaveLib/Values/SwitchpointValue.cs
@@ -21,47 +21,40 @@
  *     Project Homepage: https://github.com/genielabs/zwave-lib-dotnet
  */
 
-using System;
-
 namespace ZWaveLib
 {
-    public enum Weekday
+    public class SwitchpointValue
     {
-        None = 0,
-        Monday = 1,
-        Tuesday = 2,
-        Wednesday = 3,
-        Thursday = 4,
-        Friday = 5,
-        Saturday = 6,
-        Sunday = 7
-    }
 
-    public class ClockValue
-    {
-        public Weekday Weekday { get; set; }
-        public int Hour { get; set;}
+        public int Hour { get; set; }
+
         public int Minute { get; set; }
 
-        public static ClockValue Parse (byte [] message)
-        {
-            var value = new ClockValue ();
-
-            value.Weekday = (Weekday)(message [2] >> 5);
-            value.Hour = message [2] & 0x1f;
-            value.Minute = message [3];
-
-            return value;
-        }
+        public ScheduleStateValue State { get; set; }
 
         public byte [] GetValueBytes ()
         {
-            return new byte [] { (byte)((int)Weekday << 5 | Hour), (byte)Minute };
+            return new byte [] {
+                (byte)(Hour & 0x1f),
+                (byte)(Minute & 0x3f),
+                State.GetValueByte()
+            };
+        }
+
+        public static SwitchpointValue Parse (byte [] bytes, int offset)
+        {
+            var switchpoint = new SwitchpointValue ();
+
+            switchpoint.Hour = bytes [offset] & 0x1f;
+            switchpoint.Minute = bytes [offset + 1] & 0x3f;
+            switchpoint.State = ScheduleStateValue.Parse(bytes[offset + 2]);
+
+            return switchpoint;
         }
 
         public override string ToString ()
         {
-            return string.Format ("[ClockValue: Weekday={0}, Hour={1}, Minute={2}]", Weekday, Hour, Minute);
+            return string.Format ("[SwitchpointValue: Hour={0}, Minute={1}, State={2}]", Hour, Minute, State);
         }
     }
 }

--- a/ZWaveLib/ZWaveLib.csproj
+++ b/ZWaveLib/ZWaveLib.csproj
@@ -111,6 +111,12 @@
     <Compile Include="Values\WakeUpStatus.cs" />
     <Compile Include="CommandClasses\Clock.cs" />
     <Compile Include="Values\ClockValue.cs" />
+    <Compile Include="CommandClasses\ClimateControlSchedule.cs" />
+    <Compile Include="Values\ClimateControlScheduleValue.cs" />
+    <Compile Include="Values\SwitchpointValue.cs" />
+    <Compile Include="Values\ScheduleStateValue.cs" />
+    <Compile Include="Enums\OverrideType.cs" />
+    <Compile Include="Values\ClimateControlScheduleOverrideValue.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Implements the climate control schedule commands.  Tested using a Gen5 Z-Stick and a POPP TRV Thermostat.

The climate control schedule commands allow up to 9 temperature setpoints per day to be configured in a device.  In my use case with the TRV this allows the TRV to run through the schedule independently without having to rely on the master controller to send it commands to change its setpoint several times a day. This saves a lot of battery power in the TRV as it avoids a lot of radio communication.